### PR TITLE
🚑 Fixes service worker

### DIFF
--- a/sw.js
+++ b/sw.js
@@ -1,22 +1,32 @@
+const CACHE = 'cache-first'
+
 self.addEventListener('install', function (event) {
   event.waitUntil(
-    caches.open('sw-cache').then(function (cache) {
+    caches.open(CACHE).then(function (cache) {
       return cache.addAll(
         [
-          '/style.css',
-          '/code.js',
-          '/index.html'
+          './'
         ]
-      );
+      )
     })
   );
 });
 
-
 self.addEventListener('fetch', function (event) {
-  event.respondWith(
-    caches.match(event.request).then(function (response) {
-      return response || fetch(event.request);
+  if (navigator.onLine) {
+    fetch(event.request).then(function (response) {
+      caches.open(CACHE).then(function (cache) {
+        cache.put(event.request, response.clone());
+        return response;
+      })
     })
-  );
+  } else {
+    event.respondWith(
+      caches.open(CACHE).then(function (cache) {
+        return cache.match(event.request).then(function (response) {
+          return response
+        });
+      })
+    );
+  }
 });


### PR DESCRIPTION
Updated service worker to properly work with gh-pages as well as automatically push assets into the cache that were previously ignored by not being included in the `cache.addAll()` array 